### PR TITLE
TensorPy fix for bug in latest version of Python Imaging Library (Pillow)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 pip install --upgrade pip
 echo "Installing TensorPy..."
-pip install -r requirements.txt
+pip install -r requirements.txt --upgrade
 python setup.py install
 value="$(uname)"
 if [ $value == "Linux" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests>=2.13.0
-six>=1.10.0
-Pillow>=4.1.1
-BeautifulSoup>=3.2.1
+requests==2.18.1
+six==1.10.0
+Pillow==4.1.1
+BeautifulSoup==3.2.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='tensorpy',
-    version='1.0.17',
+    version='1.0.18',
     url='http://tensorpy.com',
     author='Michael Mintz',
     author_email='@mintzworld',

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ setup(
     description='Easy Image Classification with TensorFlow!',
     license='The MIT License',
     install_requires=[
-        'requests>=2.13.0',
-        'six>=1.10.0',
-        'Pillow>=4.1.1',
-        'BeautifulSoup>=3.2.1',
+        'requests==2.18.1',
+        'six==1.10.0',
+        'Pillow==4.1.1',
+        'BeautifulSoup==3.2.1',
     ],
     packages=['tensorpy'],
     entry_points={


### PR DESCRIPTION
The latest version of the Python Imaging Library (Pillow) appears to have a bug, which has caused TensorPy to break when downloading images and converting those images to the correct image format. To fix this, I have locked the Pillow version to 4.1.1 (errors appeared when using TensorPy with Pillow version set to 4.2.1). Sorry for any inconvenience! I have locked down dependency versions to prevent issues in the future.